### PR TITLE
Add simple integration tests and update example

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,13 +32,16 @@ jobs:
         run: |
           isort --recursive --check-only descent
           isort --recursive --check-only examples
+          isort --recursive --check-only integration-tests
 
       - name: Run black
         run: |
           black descent --check
           black examples --check
+          black integration-tests --check
 
       - name: Run flake8
         run: |
           flake8 descent
           flake8 examples
+          flake8 integration-tests

--- a/descent/metrics.py
+++ b/descent/metrics.py
@@ -6,7 +6,11 @@ import torch
 LossMetric = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
-def mse(dim: Union[int, Tuple[int, ...]] = 0) -> LossMetric:
+def mse(dim: Union[int, Tuple[int, ...]] = None) -> LossMetric:
+
+    if dim is None:
+        dim = ()
+
     def _mse(input_tensor: torch.Tensor, reference_tensor: torch.Tensor):
         return (input_tensor - reference_tensor).square().mean(dim=dim)
 

--- a/descent/tests/mocking/systems.py
+++ b/descent/tests/mocking/systems.py
@@ -1,0 +1,45 @@
+from openff.interchange.components.interchange import Interchange
+from openff.interchange.components.mdtraj import OFFBioTop
+from openff.interchange.components.potentials import Potential
+from openff.interchange.components.smirnoff import SMIRNOFFBondHandler
+from openff.interchange.models import PotentialKey, TopologyKey
+from openff.toolkit.topology import Molecule
+from openff.units import unit
+
+
+def generate_mock_hcl_system(bond_k=None, bond_length=None):
+    """Creates an interchange object for HCl that contains a single bond parameter with
+    l=1 A and k = 2 kJ / mol by default
+    """
+
+    system = Interchange()
+
+    system.topology = OFFBioTop()
+    system.topology.copy_initializer(
+        Molecule.from_mapped_smiles("[H:1][Cl:2]").to_topology()
+    )
+
+    bond_k = (
+        bond_k
+        if bond_k is not None
+        else 2.0 * unit.kilojoule / unit.mole / unit.angstrom ** 2
+    )
+    bond_length = bond_length if bond_length is not None else 1.0 * unit.angstrom
+
+    system.add_handler(
+        "Bonds",
+        SMIRNOFFBondHandler(
+            slot_map={
+                TopologyKey(atom_indices=(0, 1)): PotentialKey(
+                    id="[#1:1]-[#17:2]", associated_handler="Bonds"
+                )
+            },
+            potentials={
+                PotentialKey(
+                    id="[#1:1]-[#17:2]", associated_handler="Bonds"
+                ): Potential(parameters={"k": bond_k, "length": bond_length})
+            },
+        ),
+    )
+
+    return system

--- a/descent/tests/objectives/test_energy.py
+++ b/descent/tests/objectives/test_energy.py
@@ -4,24 +4,22 @@ from typing import Tuple
 import numpy
 import pytest
 import torch
-from openff.interchange.components.interchange import Interchange
-from openff.interchange.components.mdtraj import OFFBioTop
-from openff.interchange.components.potentials import Potential
-from openff.interchange.components.smirnoff import SMIRNOFFBondHandler
-from openff.interchange.models import PotentialKey, TopologyKey
+from openff.interchange.models import PotentialKey
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
-from openff.units import unit
 from smirnoffee.geometry.internal import detect_internal_coordinates
 
 from descent import metrics, transforms
 from descent.objectives.energy import EnergyObjective
 from descent.tests.geometric import geometric_project_derivatives
 from descent.tests.mocking.qcdata import mock_optimization_result_collection
+from descent.tests.mocking.systems import generate_mock_hcl_system
 
 
 @pytest.fixture()
 def mock_hcl_conformers() -> torch.Tensor:
+    """Creates two mock conformers for HCl - one with a bond length of 1 A and another
+    with a bond length of 2 A"""
 
     return torch.tensor(
         [[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]]
@@ -30,39 +28,7 @@ def mock_hcl_conformers() -> torch.Tensor:
 
 @pytest.fixture()
 def mock_hcl_system():
-    """Creates an interchange object for HCl that contains a single bond parameter with
-    l=1 A and k = 2 kJ / mol
-    """
-
-    system = Interchange()
-
-    system.topology = OFFBioTop()
-    system.topology.copy_initializer(
-        Molecule.from_mapped_smiles("[H:1][Cl:2]").to_topology()
-    )
-
-    system.add_handler(
-        "Bonds",
-        SMIRNOFFBondHandler(
-            slot_map={
-                TopologyKey(atom_indices=(0, 1)): PotentialKey(
-                    id="[#1:1]-[#17:2]", associated_handler="Bonds"
-                )
-            },
-            potentials={
-                PotentialKey(
-                    id="[#1:1]-[#17:2]", associated_handler="Bonds"
-                ): Potential(
-                    parameters={
-                        "k": 2.0 * unit.kilojoule / unit.mole / unit.angstrom ** 2,
-                        "length": 1.0 * unit.angstrom,
-                    }
-                )
-            },
-        ),
-    )
-
-    return system
+    return generate_mock_hcl_system()
 
 
 @pytest.fixture()

--- a/examples/energy-and-gradient.ipynb
+++ b/examples/energy-and-gradient.ipynb
@@ -3,11 +3,12 @@
   {
    "cell_type": "markdown",
    "source": [
-    "# Training Against QM Energies\n",
+    "# Training Against QM Energies and Gradients\n",
     "\n",
     "This notebook aims to show how the [`descent`](https://github.com/SimonBoothroyd/descent) framework in combination with\n",
     "[`smirnoffee`](https://github.com/SimonBoothroyd/smirnoffee) can be used to train a set of SMIRNOFF force field bond and\n",
-    "angle force constant parameters against the QM derived relative energies of a small molecule in multiple conformers.\n",
+    "angle force constant parameters against the QM computed energies and associated gradients of a small molecule in\n",
+    "multiple conformers.\n",
     "\n",
     "For the sake of clarity all warning will be disabled:"
    ],
@@ -56,7 +57,15 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.\n"
+     ]
+    }
+   ],
    "source": [
     "from qcportal import FractalClient\n",
     "\n",
@@ -89,14 +98,16 @@
   {
    "cell_type": "code",
    "source": [
-    "from openff.qcsubmit.results.filters import SMILESFilter\n",
+    "from openff.qcsubmit.results.filters import ConformerRMSDFilter, SMILESFilter\n",
     "\n",
     "result_collection = result_collection.filter(\n",
-    "    SMILESFilter(smiles_to_include=[\"CC(=O)NCC1=NC=CN1C\"])\n",
+    "    SMILESFilter(smiles_to_include=[\"CC(=O)NCC1=NC=CN1C\"]),\n",
+    "    # Only retain conformers with an RMSD greater than 0.5 Å.\n",
+    "    ConformerRMSDFilter(max_conformers=10, rmsd_tolerance=0.5)\n",
     ")\n",
     "\n",
-    "print(f\"N Molecules: {result_collection.n_molecules}\")\n",
-    "print(f\"N Molecules: {result_collection.n_results}\")"
+    "print(f\"N Molecules:  {result_collection.n_molecules}\")\n",
+    "print(f\"N Conformers: {result_collection.n_results}\")"
    ],
    "metadata": {
     "collapsed": false,
@@ -110,8 +121,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "N Molecules: 1\n",
-      "N Molecules: 6\n"
+      "N Molecules:  1\n",
+      "N Conformers: 3\n"
      ]
     }
    ]
@@ -122,19 +133,16 @@
     "You should see that our filtered collection contains the 6 results, which corresponds to 6 minimized conformers (and\n",
     "their associated energy computed using the OpenFF default B3LYP-D3BJ spec) for the molecule we filtered for above.\n",
     "\n",
-    "### Defining the Objective ( / loss) function\n",
+    "### Defining the objective ( / loss) function\n",
     "\n",
-    "For this example we will be training our force field parameters against the relative energies between the conformers we\n",
-    "retrieved above. In particular, we will use the following L2 loss function:\n",
+    "For this example we will be training our force field parameters against:\n",
     "\n",
-    "$$L2\\left(\\Delta\\theta\\right) = \\dfrac{2}{N\\left(N - 1 \\right )}\\sum ^N _{i=1} \\sum ^N_{j = i+i} \\left[ \\left(E_{QM,i}-E_{QM,j}\\right) - \\left(E_{MM,i}\\left(\\theta + \\Delta\\theta \\right) - E_{MM,j}\\left(\\theta + \\Delta\\theta \\right) \\right) \\right ]^2$$\n",
+    "* the relative energies between each conformer with the first conformer of the molecule\n",
+    "* the deviations between the QM and MM gradients projected along the redundant internal coordinates (RIC) of\n",
+    "  the molecule.\n",
     "\n",
-    "where N is the number of conformers of our given molecule, $E_{QM,i}$ the QM computed energy of conformer $i$,\n",
-    "$E_{MM,i}$ the MM energy of conformer $i$, $\\theta$ the initial force field parameters, and $\\Delta\\theta$ the\n",
-    "delta term that is being trained and added to the original force field parameters.\n",
-    "\n",
-    "This loss function is directly encoded into ``descent`` through the ``RelativeEnergyObjective`` object which can be\n",
-    "created directly from the collection of optimization results we retrieved above.\n",
+    "The construction of such a loss function is made trivial using the built-in ``EnergyObjective`` class which can be\n",
+    "created directly from the collection of optimization results we retrieved above:\n",
     "\n",
     "We first load in the initial force field parameters ($\\theta$) using the [OpenFF Toolkit](https://github.com/openforcefield/openff-toolkit):"
    ],
@@ -174,10 +182,29 @@
    "execution_count": 5,
    "outputs": [],
    "source": [
-    "from descent.objectives.energy import RelativeEnergyObjective\n",
+    "from descent import metrics, transforms\n",
+    "from descent.objectives.energy import EnergyObjective\n",
     "\n",
-    "objective_contributions = RelativeEnergyObjective.from_optimization_results(\n",
-    "    result_collection, initial_force_field, include_gradients=False\n",
+    "objective_contributions = EnergyObjective.from_optimization_results(\n",
+    "    result_collection,\n",
+    "    initial_force_field,\n",
+    "    # State that we want to include energies and gradients when computing\n",
+    "    # the contribution to the loss function.\n",
+    "    include_energies=True,\n",
+    "    include_gradients=True,\n",
+    "    # Specify that we want use energies relative to the first conformer\n",
+    "    # when evaluating the loss function\n",
+    "    energy_transforms=transforms.relative(index=0),\n",
+    "    # Use the built-in MSE metric when comparing the MM and QM relative\n",
+    "    # energies.\n",
+    "    energy_metric=metrics.mse(),\n",
+    "    # For this example with will use the QM and MM gradients directly when\n",
+    "    # computing the loss function.\n",
+    "    gradient_transforms=transforms.identity(),\n",
+    "    # Use the built-in MSE metric when comparing the MM and QM gradients\n",
+    "    gradient_metric=metrics.mse(),\n",
+    "    # State that we want to project the gradients along the RICs\n",
+    "    gradient_coordinate_system=\"ric\"\n",
     ")"
    ],
    "metadata": {
@@ -227,7 +254,7 @@
    "cell_type": "markdown",
    "source": [
     "as we filtered our initial result collection to only contain a single molecule, so too do we only have a single\n",
-    "contribution object.\n",
+    "contribution.\n",
     "\n",
     "### Specifying the parameters to train\n",
     "\n",
@@ -251,7 +278,7 @@
     "        (handler_type, potential_key, attribute)\n",
     "        for contribution in objective_contributions\n",
     "        for handler_type, potential_key, attribute in contribution.parameter_ids\n",
-    "        if attribute in \"k\" and handler_type in [\"Bonds\", \"Angles\"]\n",
+    "        if handler_type in [\"Bonds\", \"Angles\"] and attribute == \"k\"\n",
     "    },\n",
     "    key=lambda x: x[0],\n",
     "    reverse=True\n",
@@ -267,7 +294,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "where here we have made use of the ``RelativeEnergyObjective.parameter_ids`` which contains the unique identifiers of\n",
+    "where here we have made use of the ``parameter_ids`` property that contains the unique identifiers of\n",
     "the parameters that were assigned to the molecule referenced by the object."
    ],
    "metadata": {
@@ -283,7 +310,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "[('Bonds', PotentialKey(id='[#6:1]=[#8X1+0,#8X2+1:2]', mult=None), 'k'),\n ('Bonds', PotentialKey(id='[#6X3:1]=[#6X3:2]', mult=None), 'k')]"
+      "text/plain": "[('Bonds',\n  PotentialKey(id='[#6X3:1](=[#8X1+0])-[#7X3:2]', mult=None, associated_handler='Bonds'),\n  'k'),\n ('Bonds',\n  PotentialKey(id='[#6X3:1]=[#6X3:2]', mult=None, associated_handler='Bonds'),\n  'k')]"
      },
      "execution_count": 8,
      "metadata": {},
@@ -342,7 +369,7 @@
     "We are finally ready to begin training our force field parameters, or more precisely, the delta value that\n",
     "we should perturb the force field parameters by to reach better agreement with the training data.\n",
     "\n",
-    "Here we will use the 'boilerplate Pytorch optimization loop':"
+    "Here we will use the 'boilerplate `pytorch` optimization loop':"
    ],
    "metadata": {
     "collapsed": false,
@@ -359,21 +386,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 0: loss=0.10203274339437485\n",
-      "Epoch 20: loss=0.037074923515319824\n",
-      "Epoch 40: loss=0.0014350797282531857\n",
-      "Epoch 60: loss=0.0023795373272150755\n",
-      "Epoch 80: loss=0.001053333398886025\n",
-      "Epoch 100: loss=0.0008100062841549516\n",
-      "Epoch 120: loss=0.0007415462168864906\n",
-      "Epoch 140: loss=0.0006738712545484304\n",
-      "Epoch 160: loss=0.0006102666957303882\n",
-      "Epoch 180: loss=0.0005511701456271112\n"
+      "Epoch 0: loss=541.970458984375\n",
+      "Epoch 20: loss=316.5989990234375\n",
+      "Epoch 40: loss=302.3933410644531\n",
+      "Epoch 60: loss=298.25592041015625\n",
+      "Epoch 80: loss=296.67816162109375\n",
+      "Epoch 100: loss=296.056396484375\n",
+      "Epoch 120: loss=295.83831787109375\n",
+      "Epoch 140: loss=295.7755126953125\n",
+      "Epoch 160: loss=295.7544250488281\n",
+      "Epoch 180: loss=295.7417297363281\n"
      ]
     }
    ],
    "source": [
-    "lr = 0.1\n",
+    "lr = 0.01\n",
     "n_epochs = 200\n",
     "\n",
     "optimizer = torch.optim.Adam([parameter_delta], lr=lr)\n",
@@ -426,6 +453,70 @@
     "    initial_force_field, parameter_delta, parameter_delta_ids\n",
     ")\n",
     "final_force_field.to_file(\"final.offxml\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "or print out the initial and final values."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bonds SMIRKS=[#6X3:1](=[#8X1+0])-[#7X3:2] ATTR=k  INITIAL=1053.970761594 kcal/(A**2 mol)  FINAL=1053.4928565952225 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]=[#6X3:2] ATTR=k  INITIAL=857.1115548611 kcal/(A**2 mol)  FINAL=856.6519475195506 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#1:2] ATTR=k  INITIAL=758.0931772913 kcal/(A**2 mol)  FINAL=757.615259442764 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]-[#7X2:2] ATTR=k  INITIAL=837.2647972972 kcal/(A**2 mol)  FINAL=837.5914970507644 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#6X3:2]=[#8X1+0] ATTR=k  INITIAL=612.0537081219 kcal/(A**2 mol)  FINAL=612.5316650040704 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#7:1]-[#1:2] ATTR=k  INITIAL=997.7547006218 kcal/(A**2 mol)  FINAL=997.2765224160728 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]-[#1:2] ATTR=k  INITIAL=808.1394472833 kcal/(A**2 mol)  FINAL=807.6614951022607 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#6X3:2] ATTR=k  INITIAL=612.5097961064 kcal/(A**2 mol)  FINAL=612.0317996492527 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]=[#7X2,#7X3+1:2] ATTR=k  INITIAL=882.4191878243 kcal/(A**2 mol)  FINAL=881.9175979284098 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6:1]=[#8X1+0,#8X2+1:2] ATTR=k  INITIAL=1135.595318618 kcal/(A**2 mol)  FINAL=1135.1173281726021 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]-[#7X3:2] ATTR=k  INITIAL=719.219372554 kcal/(A**2 mol)  FINAL=718.7519367178918 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#7X3:2]-[#6X3]=[#8X1+0] ATTR=k  INITIAL=764.7120801727 kcal/(A**2 mol)  FINAL=765.1674802297943 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6:1]-[#7:2] ATTR=k  INITIAL=719.6326854584 kcal/(A**2 mol)  FINAL=719.1547122789749 kcal/(A**2 mol)\n",
+      "Angles SMIRKS=[*:1]~[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]~[*:3] ATTR=k  INITIAL=112.545110149 kcal/(mol rad**2)  FINAL=102.37503371799185 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[#1:1]-[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]-[*:3] ATTR=k  INITIAL=77.52610202633 kcal/(mol rad**2)  FINAL=174.6601460485996 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~;!@[*;X3;r5:2]~;@[*;r5:3] ATTR=k  INITIAL=70.66802196994 kcal/(mol rad**2)  FINAL=-10.563765656763124 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~[#6X3:2]~[*:3] ATTR=k  INITIAL=153.5899485526 kcal/(mol rad**2)  FINAL=55.08452155057894 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~[#7X2+0:2]~[*:3] ATTR=k  INITIAL=226.9001499199 kcal/(mol rad**2)  FINAL=43.02593513271265 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[#1:1]-[#6X4:2]-[#1:3] ATTR=k  INITIAL=74.28701527177 kcal/(mol rad**2)  FINAL=3.6682715114174442 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~[#6X4:2]-[*:3] ATTR=k  INITIAL=101.7373362367 kcal/(mol rad**2)  FINAL=25.96669771106467 kcal/(mol rad**2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for parameter_handler, potential_key, attribute in parameter_delta_ids:\n",
+    "\n",
+    "    initial_value = getattr(\n",
+    "        initial_force_field[parameter_handler].parameters[potential_key.id], attribute\n",
+    "    )\n",
+    "    final_value = getattr(\n",
+    "        final_force_field[parameter_handler].parameters[potential_key.id], attribute\n",
+    "    )\n",
+    "\n",
+    "    print(\n",
+    "        f\"{parameter_handler} SMIRKS={potential_key.id} ATTR={attribute}  INITIAL={initial_value}  FINAL={final_value}\"\n",
+    "    )"
    ],
    "metadata": {
     "collapsed": false,

--- a/integration-tests/test_energy_training.py
+++ b/integration-tests/test_energy_training.py
@@ -1,0 +1,180 @@
+import pytest
+import torch
+from openff.interchange.models import PotentialKey
+from openff.units import unit
+
+from descent import metrics, transforms
+from descent.objectives import ObjectiveContribution
+from descent.objectives.energy import EnergyObjective
+from descent.tests.mocking.systems import generate_mock_hcl_system
+
+
+def train_parameters(
+    loss_function: ObjectiveContribution,
+    parameter_delta_ids,
+    learning_rate: float = 0.01,
+    n_epochs: int = 200,
+    verbose: bool = True,
+) -> torch.Tensor:
+
+    parameter_delta = torch.zeros(len(parameter_delta_ids), requires_grad=True)
+
+    optimizer = torch.optim.Adam([parameter_delta], lr=learning_rate)
+
+    for epoch in range(n_epochs):
+
+        loss = loss_function(parameter_delta, parameter_delta_ids)
+
+        loss.backward()
+
+        optimizer.step()
+        optimizer.zero_grad()
+
+        if verbose and (epoch % 20 == 0 or epoch == n_epochs - 1):
+            print(f"Epoch {epoch}: loss={loss.item()}")
+
+    return parameter_delta
+
+
+@pytest.mark.parametrize(
+    "transform", [transforms.identity(), transforms.relative(index=0)]
+)
+@pytest.mark.parametrize("metric", [metrics.mse()])
+def test_energies_only(transform, metric):
+
+    conformers = torch.tensor(
+        [[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], [[-1.25, 0.0, 0.0], [1.25, 0.0, 0.0]]]
+    )
+
+    # Define the expected energies assuming that k=2.5 and l=2.0
+    reference_energies = torch.tensor(
+        [[1.25 * (distance - 2.0) ** 2] for distance in [1.0, 2.5]]
+    )
+
+    starting_system = generate_mock_hcl_system(
+        bond_k=5.0 * unit.kilojoule / unit.mole / unit.angstrom ** 2,
+        bond_length=2.0 * unit.angstrom,
+    )
+    loss_function = EnergyObjective(
+        starting_system,
+        conformers,
+        reference_energies=reference_energies,
+        energy_metric=metric,
+        energy_transforms=transform,
+    )
+
+    actual_parameter_delta = train_parameters(
+        loss_function,
+        [("Bonds", PotentialKey(id="[#1:1]-[#17:2]", associated_handler="Bonds"), "k")],
+        learning_rate=0.1,
+    )
+    expected_parameter_delta = torch.tensor([-2.5])
+
+    assert actual_parameter_delta.shape == expected_parameter_delta.shape
+    assert torch.allclose(actual_parameter_delta, expected_parameter_delta)
+
+    print(f"EXPECTED=f{expected_parameter_delta}  ACTUAL=f{actual_parameter_delta}")
+
+
+@pytest.mark.parametrize("transform", [transforms.identity()])
+@pytest.mark.parametrize("metric", [metrics.mse()])
+@pytest.mark.parametrize("coordinate_system", ["cartesian", "ric"])
+def test_forces_only(transform, metric, coordinate_system):
+
+    conformers = torch.tensor(
+        [[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], [[-1.25, 0.0, 0.0], [1.25, 0.0, 0.0]]]
+    )
+
+    # Define the expected gradients assuming that k=2.5 and l=2.0
+    reference_gradients = torch.tensor(
+        [
+            [[-2.5 * (distance - 2.0), 0.0, 0.0], [2.5 * (distance - 2.0), 0.0, 0.0]]
+            for distance in [1.0, 2.5]
+        ]
+    )
+
+    starting_system = generate_mock_hcl_system(
+        bond_k=5.0 * unit.kilojoule / unit.mole / unit.angstrom ** 2,
+        bond_length=2.0 * unit.angstrom,
+    )
+    loss_function = EnergyObjective(
+        starting_system,
+        conformers,
+        reference_gradients=reference_gradients,
+        gradient_metric=metric,
+        gradient_transforms=transform,
+        gradient_coordinate_system=coordinate_system,
+    )
+
+    actual_parameter_delta = train_parameters(
+        loss_function,
+        [("Bonds", PotentialKey(id="[#1:1]-[#17:2]", associated_handler="Bonds"), "k")],
+        learning_rate=0.1,
+    )
+    expected_parameter_delta = torch.tensor([-2.5])
+
+    assert actual_parameter_delta.shape == expected_parameter_delta.shape
+    assert torch.allclose(actual_parameter_delta, expected_parameter_delta)
+
+    print(f"EXPECTED={expected_parameter_delta}  ACTUAL={actual_parameter_delta}")
+
+
+@pytest.mark.parametrize(
+    "energy_transform", [transforms.identity(), transforms.relative(index=0)]
+)
+@pytest.mark.parametrize("energy_metric", [metrics.mse()])
+@pytest.mark.parametrize(
+    "gradient_transform", [transforms.identity(), transforms.relative(index=0)]
+)
+@pytest.mark.parametrize("gradient_metric", [metrics.mse()])
+@pytest.mark.parametrize("gradient_coordinate_system", ["cartesian", "ric"])
+def test_energies_and_forces(
+    energy_transform,
+    energy_metric,
+    gradient_transform,
+    gradient_metric,
+    gradient_coordinate_system,
+):
+
+    conformers = torch.tensor(
+        [[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], [[-1.25, 0.0, 0.0], [1.25, 0.0, 0.0]]]
+    )
+
+    # Define the expected gradients assuming that k=2.5 and l=2.0
+    reference_energies = torch.tensor(
+        [[1.25 * (distance - 2.0) ** 2] for distance in [1.0, 2.5]]
+    )
+    reference_gradients = torch.tensor(
+        [
+            [[-2.5 * (distance - 2.0), 0.0, 0.0], [2.5 * (distance - 2.0), 0.0, 0.0]]
+            for distance in [1.0, 2.5]
+        ]
+    )
+
+    starting_system = generate_mock_hcl_system(
+        bond_k=5.0 * unit.kilojoule / unit.mole / unit.angstrom ** 2,
+        bond_length=2.0 * unit.angstrom,
+    )
+    loss_function = EnergyObjective(
+        starting_system,
+        conformers,
+        reference_energies=reference_energies,
+        energy_transforms=energy_transform,
+        energy_metric=energy_metric,
+        reference_gradients=reference_gradients,
+        gradient_metric=gradient_metric,
+        gradient_transforms=gradient_transform,
+        gradient_coordinate_system=gradient_coordinate_system,
+    )
+
+    actual_parameter_delta = train_parameters(
+        loss_function,
+        [("Bonds", PotentialKey(id="[#1:1]-[#17:2]", associated_handler="Bonds"), "k")],
+        learning_rate=0.1,
+    )
+    expected_parameter_delta = torch.tensor([-2.5])
+
+    assert actual_parameter_delta.shape == expected_parameter_delta.shape
+    assert torch.allclose(actual_parameter_delta, expected_parameter_delta)
+
+    print(f"EXPECTED={expected_parameter_delta}  ACTUAL={actual_parameter_delta}")


### PR DESCRIPTION
## Description

This PR adds a set of very simple integration tests that ensure that the energy objective contribution can

i) be used in a toy parameter optimisation when both energies and gradients are being used as reference data
ii) the optimised parameters match expected values based on contrived initial perturbations.

The PR also updates the example as that also acts as a nice smoke test that at the very least the objective can be decreased.

## Status
- [X] Ready to go