### PR TITLE
Abstract parameter perturbation into NN module

### DIFF
--- a/descent/models/__init__.py
+++ b/descent/models/__init__.py
@@ -1,0 +1,3 @@
+from descent.models.models import ParameterizationModel
+
+__all__ = ["ParameterizationModel"]

--- a/descent/models/models.py
+++ b/descent/models/models.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, Tuple
+
+from smirnoffee.smirnoff import VectorizedHandler
+from typing_extensions import Protocol, runtime_checkable
+
+VectorizedSystem = Dict[Tuple[str, str], VectorizedHandler]
+
+
+@runtime_checkable
+class ParameterizationModel(Protocol):
+    """The interface the parameterization models must implement."""
+
+    def forward(self, graph: Any) -> VectorizedSystem:
+        ...

--- a/descent/models/models.py
+++ b/descent/models/models.py
@@ -11,4 +11,4 @@ class ParameterizationModel(Protocol):
     """The interface the parameterization models must implement."""
 
     def forward(self, graph: Any) -> VectorizedSystem:
-        ...
+        """Outputs a vectorised view of a parameterized molecule."""

--- a/descent/models/smirnoff.py
+++ b/descent/models/smirnoff.py
@@ -1,0 +1,134 @@
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch.nn
+from openff.interchange.models import PotentialKey
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from smirnoffee.potentials import add_parameter_delta
+
+from descent.models.models import VectorizedSystem
+from descent.utilities.smirnoff import perturb_force_field
+
+
+class SMIRNOFFModel(torch.nn.Module):
+    """A model for perturbing a set of SMIRNOFF parameters that have been applied to a
+    models via the ``openff-interchange`` package.
+    """
+
+    @property
+    def parameter_delta_ids(self) -> Tuple[Tuple[str, PotentialKey, str], ...]:
+        """
+        Returns:
+            The 'ids' of the force field parameters that will be perturbed by this model
+            where each 'id' is a tuple of ``(handler_type, smirks, attribute)``.
+        """
+
+        return tuple(
+            (handler_type, smirks, attribute)
+            for handler_type, parameter_ids in self._parameter_delta_ids.items()
+            for (smirks, attribute) in parameter_ids
+        )
+
+    def __init__(
+        self,
+        parameter_ids: List[Tuple[str, Union[str, PotentialKey], str]],
+        initial_force_field: Optional[ForceField],
+    ):
+        """
+        Args:
+            parameter_ids: A list of the 'ids' of the parameters that will be applied
+                where each id should be a tuple of ``(handler_type, smirks, attribute)``.
+            initial_force_field: The (optional) force field used to initially
+                parameterize the molecules of interest.
+        """
+
+        super(SMIRNOFFModel, self).__init__()
+
+        self._initial_force_field = initial_force_field
+
+        self._parameter_delta_ids = defaultdict(list)
+
+        for handler_type, smirks, attribute in parameter_ids:
+
+            self._parameter_delta_ids[handler_type].append(
+                (
+                    smirks
+                    if isinstance(smirks, PotentialKey)
+                    else PotentialKey(id=smirks, associated_handler=handler_type),
+                    attribute,
+                )
+            )
+
+        # Convert the ids to a normal dictionary to make sure KeyErrors get raised again.
+        self._parameter_delta_ids: Dict[str, List[Tuple[PotentialKey, str]]] = {
+            **self._parameter_delta_ids
+        }
+
+        self._parameter_delta_indices = {}
+        counter = 0
+
+        for handler_type, handler_ids in self._parameter_delta_ids.items():
+
+            self._parameter_delta_indices[handler_type] = torch.arange(
+                counter, counter + len(handler_ids), dtype=torch.int64
+            )
+
+            counter += len(handler_ids)
+
+        self.parameter_delta = torch.nn.Parameter(
+            torch.zeros(len(parameter_ids)).requires_grad_(), requires_grad=True
+        )
+
+    def forward(self, graph: VectorizedSystem) -> VectorizedSystem:
+        """Perturb the parameters of an already applied force field using this models
+        current parameter 'deltas'.
+        """
+
+        if len(self._parameter_delta_ids) == 0:
+            return graph
+
+        output = {}
+
+        for (handler_type, handler_expression), vectorized_handler in graph.items():
+
+            handler_delta_ids = self._parameter_delta_ids.get(handler_type, [])
+
+            if len(handler_delta_ids) == 0:
+
+                output[(handler_type, handler_expression)] = vectorized_handler
+                continue
+
+            handler_delta_indices = self._parameter_delta_indices[handler_type]
+            handler_delta = self.parameter_delta[handler_delta_indices]
+
+            indices, handler_parameters, handler_parameter_ids = vectorized_handler
+
+            perturbed_parameters = add_parameter_delta(
+                handler_parameters,
+                handler_parameter_ids,
+                handler_delta,
+                handler_delta_ids,
+            )
+
+            output[(handler_type, handler_expression)] = (
+                indices,
+                perturbed_parameters,
+                handler_parameter_ids,
+            )
+
+        return output
+
+    def to_force_field(self) -> ForceField:
+        """Returns the current force field (i.e. initial_force_field + parameter_delta)
+        as an OpenFF force field object.
+        """
+
+        return perturb_force_field(
+            self._initial_force_field,
+            self.parameter_delta,
+            [
+                (handler_type, smirks, attribute)
+                for handler_type, handler_ids in self._parameter_delta_ids.items()
+                for (smirks, attribute) in handler_ids
+            ],
+        )

--- a/descent/objectives/objectives.py
+++ b/descent/objectives/objectives.py
@@ -1,8 +1,10 @@
 import abc
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import torch
 from openff.interchange.models import PotentialKey
+
+from descent.models import ParameterizationModel
 
 
 class ObjectiveContribution(abc.ABC):
@@ -17,40 +19,26 @@ class ObjectiveContribution(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def evaluate(
-        self,
-        parameter_delta: Optional[torch.Tensor],
-        parameter_delta_ids: Optional[List[Tuple[str, PotentialKey, str]]],
-    ) -> torch.Tensor:
-        """Evaluate the objective at the given parameter offsets
+    def evaluate(self, model: ParameterizationModel) -> torch.Tensor:
+        """Evaluate the objective using a specified model.
 
         Args:
-            parameter_delta: An optional tensor of values to perturb the assigned
-                parameters by before evaluating the potential energy.
-            parameter_delta_ids: An optional list of ids associated with the
-                ``parameter_delta`` tensor which is used to identify which parameter
-                delta matches which assigned parameter.
+            model: The model that will return vectorized view of a parameterised
+                molecule.
 
         Returns:
             The loss contribution of this term.
         """
         raise NotImplementedError()
 
-    def __call__(
-        self,
-        parameter_delta: Optional[torch.Tensor],
-        parameter_delta_ids: Optional[List[Tuple[str, PotentialKey, str]]],
-    ) -> torch.Tensor:
-        """Evaluate the objective at the given parameter offsets
+    def __call__(self, model: ParameterizationModel) -> torch.Tensor:
+        """Evaluate the objective using a specified model.
 
         Args:
-            parameter_delta: An optional tensor of values to perturb the assigned
-                parameters by before evaluating the potential energy.
-            parameter_delta_ids: An optional list of ids associated with the
-                ``parameter_delta`` tensor which is used to identify which parameter
-                delta matches which assigned parameter.
+            model: The model that will return vectorized view of a parameterised
+                molecule.
 
         Returns:
             The loss contribution of this term.
         """
-        return self.evaluate(parameter_delta, parameter_delta_ids)
+        return self.evaluate(model)

--- a/descent/tests/models/test_smirnoff.py
+++ b/descent/tests/models/test_smirnoff.py
@@ -1,0 +1,152 @@
+import pytest
+import torch
+from openff.interchange.components.interchange import Interchange
+from openff.interchange.models import PotentialKey
+from openff.toolkit.topology import Molecule
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from smirnoffee.smirnoff import vectorize_system
+
+from descent.models import ParameterizationModel
+from descent.models.smirnoff import SMIRNOFFModel
+
+
+@pytest.fixture()
+def mock_force_field() -> ForceField:
+
+    from simtk import unit as simtk_unit
+
+    force_field = ForceField()
+
+    parameters = {
+        "Bonds": [
+            {
+                "smirks": "[#1:1]-[#9:2]",
+                "k": 1.0 * simtk_unit.kilojoules_per_mole / simtk_unit.angstrom ** 2,
+                "length": 2.0 * simtk_unit.angstrom,
+            },
+            {
+                "smirks": "[#1:1]-[#17:2]",
+                "k": 3.0 * simtk_unit.kilojoules_per_mole / simtk_unit.angstrom ** 2,
+                "length": 4.0 * simtk_unit.angstrom,
+            },
+            {
+                "smirks": "[#1:1]-[#8:2]",
+                "k": 5.0 * simtk_unit.kilojoules_per_mole / simtk_unit.angstrom ** 2,
+                "length": 6.0 * simtk_unit.angstrom,
+            },
+        ],
+        "Angles": [
+            {
+                "smirks": "[#1:1]-[#8:2]-[#1:3]",
+                "k": 1.0 * simtk_unit.kilojoules_per_mole / simtk_unit.degrees ** 2,
+                "angle": 2.0 * simtk_unit.degrees,
+            }
+        ],
+    }
+
+    for handler_type, parameter_dicts in parameters.items():
+
+        handler = force_field.get_parameter_handler(handler_type)
+
+        for parameter_dict in parameter_dicts:
+            handler.add_parameter(parameter_dict)
+
+    return force_field
+
+
+def test_model_matches_protocol():
+    assert issubclass(SMIRNOFFModel, ParameterizationModel)
+
+
+def test_model_init(mock_force_field):
+
+    expected_parameter_ids = [
+        ("Bonds", "[#1:1]-[#17:2]", "length"),
+        ("Angles", "[#1:1]-[#8:2]-[#1:3]", "angle"),
+        ("Bonds", "[#1:1]-[#9:2]", "k"),
+    ]
+
+    model = SMIRNOFFModel(expected_parameter_ids, initial_force_field=mock_force_field)
+
+    assert model._initial_force_field == mock_force_field
+
+    assert {*model._parameter_delta_ids} == {"Bonds", "Angles"}
+    assert model._parameter_delta_ids["Bonds"] == [
+        (PotentialKey(id="[#1:1]-[#17:2]", associated_handler="Bonds"), "length"),
+        (PotentialKey(id="[#1:1]-[#9:2]", associated_handler="Bonds"), "k"),
+    ]
+    assert model._parameter_delta_ids["Angles"] == [
+        (PotentialKey(id="[#1:1]-[#8:2]-[#1:3]", associated_handler="Angles"), "angle")
+    ]
+
+    assert torch.allclose(model._parameter_delta_indices["Bonds"], torch.tensor([0, 1]))
+    assert torch.allclose(model._parameter_delta_indices["Angles"], torch.tensor([2]))
+
+    assert model.parameter_delta.shape == (3,)
+
+
+def test_model_parameter_delta_ids():
+
+    input_parameter_ids = [
+        ("Bonds", "[#1:1]-[#17:2]", "length"),
+        ("Angles", "[#1:1]-[#8:2]-[#1:3]", "angle"),
+        ("Bonds", "[#1:1]-[#9:2]", "k"),
+    ]
+    expected_parameter_ids = tuple(
+        (
+            handler_type,
+            PotentialKey(id=smirks, associated_handler=handler_type),
+            attribute,
+        )
+        for handler_type, smirks, attribute in [
+            ("Bonds", "[#1:1]-[#17:2]", "length"),
+            ("Bonds", "[#1:1]-[#9:2]", "k"),
+            ("Angles", "[#1:1]-[#8:2]-[#1:3]", "angle"),
+        ]
+    )
+
+    model = SMIRNOFFModel(input_parameter_ids, None)
+    assert model.parameter_delta_ids == expected_parameter_ids
+
+
+def test_model_forward_empty_input():
+
+    model = SMIRNOFFModel([("Bonds", "[#1:1]-[#17:2]", "length")], None)
+    assert model.forward({}) == {}
+
+
+def test_model_forward(mock_force_field):
+
+    molecule = Molecule.from_smiles("[H]Cl")
+    system = Interchange.from_smirnoff(mock_force_field, molecule.to_topology())
+
+    model = SMIRNOFFModel([("Bonds", "[#1:1]-[#17:2]", "length")], None)
+    model.parameter_delta = torch.nn.Parameter(
+        model.parameter_delta + torch.tensor([1.0]), requires_grad=True
+    )
+
+    input_system = vectorize_system(system)
+    output_system = model.forward(input_system)
+
+    assert torch.isclose(
+        output_system[("Bonds", "k/2*(r-length)**2")][1][0, 1], torch.tensor(5.0)
+    )
+
+
+def test_model_forward_fixed_handler(mock_force_field):
+    """Test that forward works for the case where a system contains a handler that
+    contains no parameters being trained."""
+
+    molecule = Molecule.from_smiles("O")
+    system = Interchange.from_smirnoff(mock_force_field, molecule.to_topology())
+
+    model = SMIRNOFFModel([("Bonds", "[#1:1]-[#17:2]", "length")], None)
+
+    input_system = vectorize_system(system)
+    output_system = model.forward(input_system)
+
+    assert ("Angles", "k/2*(theta-angle)**2") in output_system
+
+    assert len(output_system[("Angles", "k/2*(theta-angle)**2")][0]) == 1
+    assert len(output_system[("Angles", "k/2*(theta-angle)**2")][1]) == 1
+    assert len(output_system[("Angles", "k/2*(theta-angle)**2")][2]) == 1

--- a/descent/tests/objectives/test_energy.py
+++ b/descent/tests/objectives/test_energy.py
@@ -10,6 +10,7 @@ from openff.toolkit.typing.engines.smirnoff import ForceField
 from smirnoffee.geometry.internal import detect_internal_coordinates
 
 from descent import metrics, transforms
+from descent.models.smirnoff import SMIRNOFFModel
 from descent.objectives.energy import EnergyObjective
 from descent.tests.geometric import geometric_project_derivatives
 from descent.tests.mocking.qcdata import mock_optimization_result_collection
@@ -150,7 +151,7 @@ def test_evaluate_mm_energies(
     )
 
     mm_energies, mm_gradients, mm_hessians = energy_objective._evaluate_mm_energies(
-        None, None, compute_gradients, compute_hessians
+        SMIRNOFFModel([], ForceField), compute_gradients, compute_hessians
     )
 
     expected_energies, expected_gradients, expected_hessians = mock_hcl_mm_values
@@ -184,7 +185,7 @@ def test_evaluate_energies(mock_hcl_conformers, mock_hcl_system, mock_hcl_mm_val
         energy_metric=metrics.mse(),
     )
 
-    loss = energy_objective.evaluate(None, None)
+    loss = energy_objective.evaluate(SMIRNOFFModel([], ForceField))
 
     assert loss.shape == (1,)
     assert torch.isclose(loss, expected_scale.square())
@@ -206,7 +207,7 @@ def test_evaluate_gradients(mock_hcl_conformers, mock_hcl_system, mock_hcl_mm_va
         gradient_metric=metrics.mse(()),
     )
 
-    loss = energy_objective.evaluate(None, None)
+    loss = energy_objective.evaluate(SMIRNOFFModel([], ForceField))
 
     assert loss.shape == (1,)
     assert torch.isclose(loss, expected_scale.square())
@@ -229,7 +230,7 @@ def test_evaluate_hessians(mock_hcl_conformers, mock_hcl_system, mock_hcl_mm_val
         hessian_metric=metrics.mse(()),
     )
 
-    loss = energy_objective.evaluate(None, None)
+    loss = energy_objective.evaluate(SMIRNOFFModel([], ForceField))
 
     assert loss.shape == (1,)
     assert torch.isclose(loss, expected_scale.square())

--- a/descent/tests/objectives/test_objectives.py
+++ b/descent/tests/objectives/test_objectives.py
@@ -1,5 +1,6 @@
-import torch
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
+from descent.models.smirnoff import SMIRNOFFModel
 from descent.objectives import ObjectiveContribution
 
 
@@ -12,10 +13,10 @@ def test_call(monkeypatch):
         def parameter_ids(self):
             return []
 
-        def evaluate(self, parameter_delta, parameter_delta_ids):
+        def evaluate(self, model):
 
             nonlocal evaluate_called
             evaluate_called = True
 
-    DummyObjective()(torch.tensor([]), [])
+    DummyObjective()(SMIRNOFFModel([], ForceField))
     assert evaluate_called

--- a/examples/energy-and-gradient.ipynb
+++ b/examples/energy-and-gradient.ipynb
@@ -256,10 +256,9 @@
     "as we filtered our initial result collection to only contain a single molecule, so too do we only have a single\n",
     "contribution.\n",
     "\n",
-    "### Specifying the parameters to train\n",
+    "### Defining the 'model'\n",
     "\n",
-    "For this example will will train all of the bond and force constants that were assigned to our molecule\n",
-    "of interest:"
+    "For this example we will train all the bond and force constants that were assigned to our molecule of interest:"
    ],
    "metadata": {
     "collapsed": false,
@@ -310,7 +309,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "[('Bonds',\n  PotentialKey(id='[#6X3:1](=[#8X1+0])-[#7X3:2]', mult=None, associated_handler='Bonds'),\n  'k'),\n ('Bonds',\n  PotentialKey(id='[#6X3:1]=[#6X3:2]', mult=None, associated_handler='Bonds'),\n  'k')]"
+      "text/plain": "[('Bonds',\n  PotentialKey(id='[#6X3:1]-[#7X3:2]', mult=None, associated_handler='Bonds'),\n  'k'),\n ('Bonds',\n  PotentialKey(id='[#6X3:1]-[#7X2:2]', mult=None, associated_handler='Bonds'),\n  'k')]"
      },
      "execution_count": 8,
      "metadata": {},
@@ -330,11 +329,12 @@
   {
    "cell_type": "markdown",
    "source": [
-    "These ids are comprised of the type of SMIRNOFF parameter handler that the parameter originated from,\n",
+    "These 'ids' are comprised of the type of SMIRNOFF parameter handler that the parameter originated from,\n",
     "a key containing the id (in this case the SMIRKS pattern) associated with the parameter and the specific\n",
     "attribute of the parameter (e.g. the force constant ``k``).\n",
     "\n",
-    "These keys will allow us to map our tensor of delta values:"
+    "These keys will allow us to define the 'model' that will take an already parameterised system stored in an\n",
+    "``Interchange`` object and perturb the parameters based on the current values of the parameters being trained:"
    ],
    "metadata": {
     "collapsed": false,
@@ -348,9 +348,9 @@
    "execution_count": 9,
    "outputs": [],
    "source": [
-    "import torch\n",
+    "from descent.models.smirnoff import SMIRNOFFModel\n",
     "\n",
-    "parameter_delta = torch.zeros(len(parameter_delta_ids), requires_grad=True)"
+    "model = SMIRNOFFModel(parameter_delta_ids, initial_force_field)"
    ],
    "metadata": {
     "collapsed": false,
@@ -387,30 +387,32 @@
      "output_type": "stream",
      "text": [
       "Epoch 0: loss=541.970458984375\n",
-      "Epoch 20: loss=316.5989990234375\n",
+      "Epoch 20: loss=316.5990295410156\n",
       "Epoch 40: loss=302.3933410644531\n",
-      "Epoch 60: loss=298.25592041015625\n",
-      "Epoch 80: loss=296.67816162109375\n",
-      "Epoch 100: loss=296.056396484375\n",
-      "Epoch 120: loss=295.83831787109375\n",
+      "Epoch 60: loss=298.2558288574219\n",
+      "Epoch 80: loss=296.6781921386719\n",
+      "Epoch 100: loss=296.0563659667969\n",
+      "Epoch 120: loss=295.8383483886719\n",
       "Epoch 140: loss=295.7755126953125\n",
       "Epoch 160: loss=295.7544250488281\n",
-      "Epoch 180: loss=295.7417297363281\n"
+      "Epoch 180: loss=295.7417907714844\n"
      ]
     }
    ],
    "source": [
+    "import torch\n",
+    "\n",
     "lr = 0.01\n",
     "n_epochs = 200\n",
     "\n",
-    "optimizer = torch.optim.Adam([parameter_delta], lr=lr)\n",
+    "optimizer = torch.optim.Adam([model.parameter_delta], lr=lr)\n",
     "\n",
     "for epoch in range(n_epochs):\n",
     "\n",
     "    loss = torch.zeros(1)\n",
     "\n",
     "    for objective_contribution in objective_contributions:\n",
-    "        loss += objective_contribution(parameter_delta, parameter_delta_ids)\n",
+    "        loss += objective_contribution(model)\n",
     "\n",
     "    loss.backward()\n",
     "\n",
@@ -447,11 +449,7 @@
    "execution_count": 11,
    "outputs": [],
    "source": [
-    "from descent.utilities.smirnoff import perturb_force_field\n",
-    "\n",
-    "final_force_field = perturb_force_field(\n",
-    "    initial_force_field, parameter_delta, parameter_delta_ids\n",
-    ")\n",
+    "final_force_field = model.to_force_field()\n",
     "final_force_field.to_file(\"final.offxml\")"
    ],
    "metadata": {
@@ -481,26 +479,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bonds SMIRKS=[#6X3:1](=[#8X1+0])-[#7X3:2] ATTR=k  INITIAL=1053.970761594 kcal/(A**2 mol)  FINAL=1053.4928565952225 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X3:1]=[#6X3:2] ATTR=k  INITIAL=857.1115548611 kcal/(A**2 mol)  FINAL=856.6519475195506 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X4:1]-[#1:2] ATTR=k  INITIAL=758.0931772913 kcal/(A**2 mol)  FINAL=757.615259442764 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]-[#7X3:2] ATTR=k  INITIAL=719.219372554 kcal/(A**2 mol)  FINAL=718.7519367748752 kcal/(A**2 mol)\n",
       "Bonds SMIRKS=[#6X3:1]-[#7X2:2] ATTR=k  INITIAL=837.2647972972 kcal/(A**2 mol)  FINAL=837.5914970507644 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X4:1]-[#6X3:2]=[#8X1+0] ATTR=k  INITIAL=612.0537081219 kcal/(A**2 mol)  FINAL=612.5316650040704 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#7:1]-[#1:2] ATTR=k  INITIAL=997.7547006218 kcal/(A**2 mol)  FINAL=997.2765224160728 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X3:1]-[#1:2] ATTR=k  INITIAL=808.1394472833 kcal/(A**2 mol)  FINAL=807.6614951022607 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X4:1]-[#6X3:2] ATTR=k  INITIAL=612.5097961064 kcal/(A**2 mol)  FINAL=612.0317996492527 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X3:1]=[#7X2,#7X3+1:2] ATTR=k  INITIAL=882.4191878243 kcal/(A**2 mol)  FINAL=881.9175979284098 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6:1]=[#8X1+0,#8X2+1:2] ATTR=k  INITIAL=1135.595318618 kcal/(A**2 mol)  FINAL=1135.1173281726021 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X3:1]-[#7X3:2] ATTR=k  INITIAL=719.219372554 kcal/(A**2 mol)  FINAL=718.7519367178918 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6X4:1]-[#7X3:2]-[#6X3]=[#8X1+0] ATTR=k  INITIAL=764.7120801727 kcal/(A**2 mol)  FINAL=765.1674802297943 kcal/(A**2 mol)\n",
-      "Bonds SMIRKS=[#6:1]-[#7:2] ATTR=k  INITIAL=719.6326854584 kcal/(A**2 mol)  FINAL=719.1547122789749 kcal/(A**2 mol)\n",
-      "Angles SMIRKS=[*:1]~[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]~[*:3] ATTR=k  INITIAL=112.545110149 kcal/(mol rad**2)  FINAL=102.37503371799185 kcal/(mol rad**2)\n",
-      "Angles SMIRKS=[#1:1]-[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]-[*:3] ATTR=k  INITIAL=77.52610202633 kcal/(mol rad**2)  FINAL=174.6601460485996 kcal/(mol rad**2)\n",
-      "Angles SMIRKS=[*:1]~;!@[*;X3;r5:2]~;@[*;r5:3] ATTR=k  INITIAL=70.66802196994 kcal/(mol rad**2)  FINAL=-10.563765656763124 kcal/(mol rad**2)\n",
-      "Angles SMIRKS=[*:1]~[#6X3:2]~[*:3] ATTR=k  INITIAL=153.5899485526 kcal/(mol rad**2)  FINAL=55.08452155057894 kcal/(mol rad**2)\n",
-      "Angles SMIRKS=[*:1]~[#7X2+0:2]~[*:3] ATTR=k  INITIAL=226.9001499199 kcal/(mol rad**2)  FINAL=43.02593513271265 kcal/(mol rad**2)\n",
-      "Angles SMIRKS=[#1:1]-[#6X4:2]-[#1:3] ATTR=k  INITIAL=74.28701527177 kcal/(mol rad**2)  FINAL=3.6682715114174442 kcal/(mol rad**2)\n",
-      "Angles SMIRKS=[*:1]~[#6X4:2]-[*:3] ATTR=k  INITIAL=101.7373362367 kcal/(mol rad**2)  FINAL=25.96669771106467 kcal/(mol rad**2)\n"
+      "Bonds SMIRKS=[#7:1]-[#1:2] ATTR=k  INITIAL=997.7547006218 kcal/(A**2 mol)  FINAL=997.2765223590894 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#7X3:2]-[#6X3]=[#8X1+0] ATTR=k  INITIAL=764.7120801727 kcal/(A**2 mol)  FINAL=765.1674806286782 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#1:2] ATTR=k  INITIAL=758.0931772913 kcal/(A**2 mol)  FINAL=757.615259442764 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#6X3:2] ATTR=k  INITIAL=612.5097961064 kcal/(A**2 mol)  FINAL=612.0317997062361 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]=[#7X2,#7X3+1:2] ATTR=k  INITIAL=882.4191878243 kcal/(A**2 mol)  FINAL=881.9175979853932 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6:1]=[#8X1+0,#8X2+1:2] ATTR=k  INITIAL=1135.595318618 kcal/(A**2 mol)  FINAL=1135.1173281441104 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1](=[#8X1+0])-[#7X3:2] ATTR=k  INITIAL=1053.970761594 kcal/(A**2 mol)  FINAL=1053.4928565952225 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6:1]-[#7:2] ATTR=k  INITIAL=719.6326854584 kcal/(A**2 mol)  FINAL=719.1547123359583 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]-[#1:2] ATTR=k  INITIAL=808.1394472833 kcal/(A**2 mol)  FINAL=807.6614951877358 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X3:1]=[#6X3:2] ATTR=k  INITIAL=857.1115548611 kcal/(A**2 mol)  FINAL=856.6519474625673 kcal/(A**2 mol)\n",
+      "Bonds SMIRKS=[#6X4:1]-[#6X3:2]=[#8X1+0] ATTR=k  INITIAL=612.0537081219 kcal/(A**2 mol)  FINAL=612.5316651180373 kcal/(A**2 mol)\n",
+      "Angles SMIRKS=[*:1]~[#7X2+0:2]~[*:3] ATTR=k  INITIAL=226.9001499199 kcal/(mol rad**2)  FINAL=43.02592344111929 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~[#6X4:2]-[*:3] ATTR=k  INITIAL=101.7373362367 kcal/(mol rad**2)  FINAL=25.96669771106467 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]~[*:3] ATTR=k  INITIAL=112.545110149 kcal/(mol rad**2)  FINAL=102.37502933364435 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~;!@[*;X3;r5:2]~;@[*;r5:3] ATTR=k  INITIAL=70.66802196994 kcal/(mol rad**2)  FINAL=-10.563753965169767 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[*:1]~[#6X3:2]~[*:3] ATTR=k  INITIAL=153.5899485526 kcal/(mol rad**2)  FINAL=55.0845332421723 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[#1:1]-[#6X4:2]-[#1:3] ATTR=k  INITIAL=74.28701527177 kcal/(mol rad**2)  FINAL=3.668236436637386 kcal/(mol rad**2)\n",
+      "Angles SMIRKS=[#1:1]-[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]-[*:3] ATTR=k  INITIAL=77.52610202633 kcal/(mol rad**2)  FINAL=174.66015189439625 kcal/(mol rad**2)\n"
      ]
     }
    ],


### PR DESCRIPTION
## Description

This PR abstracts the code to no longer expect `smirnoffee` type parameter perturbation tensors and id lists, but rather a `torch.nn.Module` that should take as input some information about a molecule (whether that be a DGL graph or a vectorised system) and output an 'up to date' vectorized representation of the system.

This abstraction should a) make integration with things like PyTorch Lightning easier and b) make it so that NN models like those built with `espaloma` can make use of the objectives defined here.

## Status
- [x] Ready to go