### PR TITLE
Add support for SMIRNOFF covariance tensor

### DIFF
--- a/descent/objectives/energy.py
+++ b/descent/objectives/energy.py
@@ -690,7 +690,7 @@ class EnergyObjective(ObjectiveContribution):
         hessian_coordinate_system: Literal["cartesian", "ric"] = "cartesian",
     ) -> List["EnergyObjective"]:
         """Creates a list of energy objective contribution terms (one per unique
-        molecule) from a set of QC optimization results.
+        molecule) from the **final** structures a set of QC optimization results.
 
         Args:
             optimization_results: The collection of result records.


### PR DESCRIPTION
## Description

This PR adds a new `covariance_tensor` argument to the SMIRNOFF model that allows users to apply a transform to the 'parameter delta' before it is applied to a parameterised system. This allows parameters to easily be scaled or be made linear combinations of one another much like `forcebalance`'s mathematical vs physical parameters and parameter eval statements.

## Status
- [ ] Ready to go