### PR TITLE
Support molecules with conformers with different ICs

### DIFF
--- a/descent/tests/objectives/test_energy.py
+++ b/descent/tests/objectives/test_energy.py
@@ -98,7 +98,7 @@ def test_initialize_internal_coordinates():
             [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 1.0, 0.0]],
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
         ],
-        requires_grad=True
+        requires_grad=True,
     )
 
     objective = EnergyObjective.__new__(EnergyObjective)

--- a/devtools/conda-envs/meta.yaml
+++ b/devtools/conda-envs/meta.yaml
@@ -21,7 +21,7 @@ dependencies:
 
   - openff-qcsubmit >= 0.2.2
 
-  - smirnoffee
+  - smirnoffee >=0.0.1a2
   - pytorch >= 1.9.0
 
   - pydantic


### PR DESCRIPTION
## Description

This PR ensures that molecules that have conformers that map to different internal coordinates e.g. one conformer has a planar N and another a pyramidal N, are correctly handled by padding the B and G matrices with zeros so they can be batched together.

## Status
- [X] Ready to go