### PR TITLE
Add approximate hessian utility

### DIFF
--- a/descent/tests/utils/test_loss.py
+++ b/descent/tests/utils/test_loss.py
@@ -1,6 +1,6 @@
 import torch
 
-from descent.utils.loss import to_closure
+from descent.utils.loss import approximate_hessian, to_closure
 
 
 def test_to_closure():
@@ -35,3 +35,21 @@ def test_to_closure():
     assert loss is not None
     assert grad is not None
     assert hess is None
+
+
+def test_approximate_hessian():
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
+    y_pred = 5.0 * x**2 + 3.0 * x + 2.0
+
+    actual_hessian = approximate_hessian(x, y_pred)
+    expected_hess = torch.tensor(
+        [
+            [338.0, 0.0, 0.0, 0.0],
+            [0.0, 1058.0, 0.0, 0.0],
+            [0.0, 0.0, 2178.0, 0.0],
+            [0.0, 0.0, 0.0, 3698.0],
+        ]
+    )
+
+    assert actual_hessian.shape == expected_hess.shape
+    assert torch.allclose(actual_hessian, expected_hess)

--- a/descent/utils/loss.py
+++ b/descent/utils/loss.py
@@ -51,3 +51,23 @@ def to_closure(
         return loss.detach(), gradient, hessian
 
     return closure_fn
+
+
+def approximate_hessian(x: torch.Tensor, y_pred: torch.Tensor):
+    """Compute the outer product approximation of the hessian of a least squares
+    loss function of the sum ``sum((y_pred - y_ref)**2)``.
+
+    Args:
+        x: The parameter tensor with ``shape=(n_parameters,)``.
+        y_pred: The values predicted using ``x`` with ``shape=(n_predications,)``.
+
+    Returns:
+        The outer product approximation of the hessian with ``shape=n_parameters
+    """
+
+    y_pred_grad = [torch.autograd.grad(y, x, retain_graph=True)[0] for y in y_pred]
+    y_pred_grad = torch.stack(y_pred_grad, dim=0)
+
+    return (
+        2.0 * torch.einsum("bi,bj->bij", y_pred_grad, y_pred_grad).sum(dim=0)
+    ).detach()


### PR DESCRIPTION
## Description

This PR adds a utility to compute the approximate hessian using the outer product approximation. This is useful, for e.g., when optimizing physical properties whose hessian cannot yet be analytically computed.

## Status
- [X] Ready to go