### PR TITLE
Fix using v-sites with DES datasets

### DIFF
--- a/descent/targets/dimers.py
+++ b/descent/targets/dimers.py
@@ -138,7 +138,7 @@ def create_from_des(
                 for geometry_id in geometry_ids
             ]
 
-            coords = torch.tensor(coords_raw)
+            coords = torch.tensor(coords_raw, dtype=torch.float64)
             energy = energy_fn(group_data, geometry_ids, coords)
 
             dimer = {


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

This PR changes the dtype of the loaded coordinates of the DES datasets to torch.float64 to make them compatible with the v-site weights. 

## Status
- [ ] Ready to go