### PR TITLE
Fix docs builds

### DIFF
--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -55,7 +55,6 @@ dependencies:
   - mkdocs-material
   - mkdocs-gen-files
   - mkdocs-literate-nav
-  - mkdocs-jupyter
   - mkdocstrings
   - mkdocstrings-python
   - black

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,8 +84,8 @@ plugins:
 - gen-files:
     scripts:
     - docs/scripts/gen_ref_pages.py
-- mkdocs-jupyter:
-    include: [ "examples/*.ipynb" ]
+#- mkdocs-jupyter:
+#    include: [ "examples/*.ipynb" ]
 - literate-nav:
     nav_file: SUMMARY.md
 - mkdocstrings:


### PR DESCRIPTION
## Description

There was an API change in MkDocs which breaks the Jupyter plugin. It doesn't get used in this repo so it is removed here.

## Status
- [X] Ready to go