### PR TITLE
Fix incorrect force sign in energy target

### DIFF
--- a/descent/targets/energy.py
+++ b/descent/targets/energy.py
@@ -119,7 +119,7 @@ def predict(
         topology = topologies[smiles]
 
         energy_pred = smee.compute_energy(topology, force_field, coords)
-        forces_pred = torch.autograd.grad(
+        forces_pred = -torch.autograd.grad(
             energy_pred.sum(),
             coords,
             create_graph=True,

--- a/descent/tests/targets/test_energy.py
+++ b/descent/tests/targets/test_energy.py
@@ -82,7 +82,7 @@ def test_extract_smiles(mock_meoh_entry, mock_hoh_entry):
             )
             / math.sqrt(6.0 * 3.0),
             torch.tensor([7.899425506591797, -7.89942741394043]) / math.sqrt(2.0),
-            torch.tensor(
+            -torch.tensor(
                 [
                     [0.0, 83.55978393554688, 0.0],
                     [-161.40325927734375, -41.77988815307617, 0.0],
@@ -109,7 +109,7 @@ def test_extract_smiles(mock_meoh_entry, mock_hoh_entry):
                 ]
             ),
             torch.tensor([0.0, -15.798852920532227]),
-            torch.tensor(
+            -torch.tensor(
                 [
                     [0.0, 83.55978393554688, 0.0],
                     [-161.40325927734375, -41.77988815307617, 0.0],


### PR DESCRIPTION
## Description

This PR fixes a typo where the gradient, rather than force was returned for the energy target

## Status
- [X] Ready to go