### PR TITLE
Fix energy test by using unconstrained force field

### DIFF
--- a/descent/targets/dimers.py
+++ b/descent/targets/dimers.py
@@ -409,7 +409,7 @@ def report(
         col: rmse_format for col in data_stats.columns if col.startswith("RMSE")
     }
     formatters_full = {
-        **{col: "html" for col in ["Dimer", "Energy [kcal/mol]"]},
+        **dict.fromkeys(["Dimer", "Energy [kcal/mol]"], "html"),
         **{col: rmse_format for col in data_full.columns if col.startswith("RMSE")},
     }
 

--- a/descent/targets/energy.py
+++ b/descent/targets/energy.py
@@ -116,8 +116,8 @@ def predict(
         )
 
         coords = (
-            coords_flat.reshape(len(energy_ref), -1, 3)
-        ).detach().requires_grad_(True)
+            (coords_flat.reshape(len(energy_ref), -1, 3)).detach().requires_grad_(True)
+        )
         topology = topologies[smiles]
 
         energy_pred = smee.compute_energy(topology, force_field, coords)

--- a/descent/targets/thermo.py
+++ b/descent/targets/thermo.py
@@ -703,7 +703,7 @@ def predict(
 
             verbose_rows.append(
                 {
-                    "type": f'{entry["type"]} [{entry["units"]}]',
+                    "type": f"{entry['type']} [{entry['units']}]",
                     "smiles_a": descent.utils.molecule.unmap_smiles(entry["smiles_a"]),
                     "smiles_b": (
                         ""

--- a/descent/tests/targets/test_energy.py
+++ b/descent/tests/targets/test_energy.py
@@ -78,7 +78,8 @@ def test_extract_smiles(mock_meoh_entry, mock_hoh_entry):
                     [9.0, 10.0, 11.0],
                     [12.0, 13.0, 14.0],
                     [15.0, 16.0, 17.0],
-                ], dtype=torch.float64
+                ],
+                dtype=torch.float64,
             )
             / math.sqrt(6.0 * 3.0),
             torch.tensor([7.899425506591797, -7.89942741394043]) / math.sqrt(2.0),
@@ -90,7 +91,8 @@ def test_extract_smiles(mock_meoh_entry, mock_hoh_entry):
                     [0.0, -137.45770263671875, 0.0],
                     [102.62999725341797, 68.72884368896484, 0.0],
                     [-102.62999725341797, 68.72884368896484, 0.0],
-                ], dtype=torch.float64
+                ],
+                dtype=torch.float64,
             )
             / math.sqrt(6.0 * 3.0),
         ),
@@ -106,7 +108,8 @@ def test_extract_smiles(mock_meoh_entry, mock_hoh_entry):
                     [9.0, 10.0, 11.0],
                     [12.0, 13.0, 14.0],
                     [15.0, 16.0, 17.0],
-                ], dtype=torch.float64
+                ],
+                dtype=torch.float64,
             ),
             torch.tensor([0.0, -15.798852920532227]),
             -torch.tensor(
@@ -117,7 +120,8 @@ def test_extract_smiles(mock_meoh_entry, mock_hoh_entry):
                     [0.0, -137.45770263671875, 0.0],
                     [102.62999725341797, 68.72884368896484, 0.0],
                     [-102.62999725341797, 68.72884368896484, 0.0],
-                ], dtype=torch.float64
+                ],
+                dtype=torch.float64,
             ),
         ),
     ],

--- a/descent/train.py
+++ b/descent/train.py
@@ -212,9 +212,9 @@ class Trainable:
             potential_config = config[potential_type]
 
             potential_cols = getattr(potential, f"{attr[:-1]}_cols")
-            assert (
-                len({*potential_config.cols} - {*potential_cols}) == 0
-            ), f"unknown columns: {potential_cols}"
+            assert len({*potential_config.cols} - {*potential_cols}) == 0, (
+                f"unknown columns: {potential_cols}"
+            )
 
             potential_values = getattr(potential, attr).detach().clone()
             potential_values_flat = potential_values.flatten()

--- a/descent/utils/loss.py
+++ b/descent/utils/loss.py
@@ -73,7 +73,7 @@ def combine_closures(
         A combined closure function.
     """
 
-    weights = weights if weights is not None else {name: 1.0 for name in closures}
+    weights = weights if weights is not None else dict.fromkeys(closures, 1.0)
 
     if len(closures) == 0:
         raise NotImplementedError("At least one closure function is required.")

--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -11,6 +11,7 @@ dependencies:
   # Core packages
   - smee >=0.10.0
   - pydantic-units  # TODO: Remove this line once smee deps are updated
+  - openff-interchange=0.3.17
 
   - pytorch
   - pyarrow


### PR DESCRIPTION
## Description

`descent/tests/targets/test_energy.py::test_predict` was failing as the expected bond energy component was removed due to the presence of H-bond constraints in the force field. Using the unconstrained version of the force field ensures that this energy component is not removed.


## Status
- [x] Ready to go