### PR TITLE
Add create from generator

### DIFF
--- a/descent/targets/dimers.py
+++ b/descent/targets/dimers.py
@@ -80,6 +80,38 @@ def create_dataset(dimers: list[Dimer]) -> datasets.Dataset:
     return dataset
 
 
+def create_dataset_from_generator(
+    gen_fn: typing.Callable[[], typing.Iterator[Dimer]],
+) -> datasets.Dataset:
+    """Create a dataset from a generator function, avoiding loading all dimers into
+    memory at once.
+
+    Args:
+        gen_fn: A callable that returns an iterator of dimers. It will be called by
+            the HuggingFace datasets library and must be re-iterable (i.e. each call
+            to ``gen_fn()`` should produce a fresh iterator).
+
+    Returns:
+        The created dataset.
+    """
+
+    def _gen():
+        for dimer in gen_fn():
+            yield {
+                "smiles_a": dimer["smiles_a"],
+                "smiles_b": dimer["smiles_b"],
+                "coords": torch.tensor(dimer["coords"]).flatten().tolist(),
+                "energy": torch.tensor(dimer["energy"]).flatten().tolist(),
+                "source": dimer["source"],
+            }
+
+    features = datasets.Features.from_arrow_schema(DATA_SCHEMA)
+    dataset = datasets.Dataset.from_generator(_gen, features=features)
+    dataset.set_format("torch")
+
+    return dataset
+
+
 def create_from_des(
     data_dir: pathlib.Path,
     energy_fn: EnergyFn,

--- a/descent/targets/energy.py
+++ b/descent/targets/energy.py
@@ -64,6 +64,37 @@ def create_dataset(entries: list[Entry]) -> datasets.Dataset:
     return dataset
 
 
+def create_dataset_from_generator(
+    gen_fn: typing.Callable[[], typing.Iterator[Entry]],
+) -> datasets.Dataset:
+    """Create a dataset from a generator function, avoiding loading all entries into
+    memory at once.
+
+    Args:
+        gen_fn: A callable that returns an iterator of entries. It will be called by
+            the HuggingFace datasets library and must be re-iterable (i.e. each call
+            to ``gen_fn()`` should produce a fresh iterator).
+
+    Returns:
+        The created dataset.
+    """
+
+    def _gen():
+        for entry in gen_fn():
+            yield {
+                "smiles": entry["smiles"],
+                "coords": torch.tensor(entry["coords"]).flatten().tolist(),
+                "energy": torch.tensor(entry["energy"]).flatten().tolist(),
+                "forces": torch.tensor(entry["forces"]).flatten().tolist(),
+            }
+
+    features = datasets.Features.from_arrow_schema(DATA_SCHEMA)
+    dataset = datasets.Dataset.from_generator(_gen, features=features)
+    dataset.set_format("torch")
+
+    return dataset
+
+
 def extract_smiles(dataset: datasets.Dataset) -> list[str]:
     """Return a list of unique SMILES strings in the dataset.
 

--- a/descent/tests/targets/test_dimers.py
+++ b/descent/tests/targets/test_dimers.py
@@ -10,6 +10,7 @@ from descent.targets.dimers import (
     Dimer,
     compute_dimer_energy,
     create_dataset,
+    create_dataset_from_generator,
     create_from_des,
     default_closure,
     extract_smiles,
@@ -41,6 +42,24 @@ def test_create_dataset(mock_dimer):
     ]
 
     dataset = create_dataset([mock_dimer])
+    assert len(dataset) == 1
+
+    entries = list(descent.utils.dataset.iter_dataset(dataset))
+    assert entries == expected_entries
+
+
+def test_create_dataset_from_generator(mock_dimer):
+    expected_entries = [
+        {
+            "smiles_a": mock_dimer["smiles_a"],
+            "smiles_b": mock_dimer["smiles_b"],
+            "coords": pytest.approx(mock_dimer["coords"].flatten()),
+            "energy": pytest.approx(mock_dimer["energy"]),
+            "source": mock_dimer["source"],
+        },
+    ]
+
+    dataset = create_dataset_from_generator(lambda: iter([mock_dimer]))
     assert len(dataset) == 1
 
     entries = list(descent.utils.dataset.iter_dataset(dataset))

--- a/descent/tests/targets/test_energy.py
+++ b/descent/tests/targets/test_energy.py
@@ -7,7 +7,13 @@ import smee.converters
 import torch
 
 import descent.utils.dataset
-from descent.targets.energy import Entry, create_dataset, extract_smiles, predict
+from descent.targets.energy import (
+    Entry,
+    create_dataset,
+    create_dataset_from_generator,
+    extract_smiles,
+    predict,
+)
 
 
 @pytest.fixture
@@ -46,6 +52,23 @@ def test_create_dataset(mock_meoh_entry):
     ]
 
     dataset = create_dataset([mock_meoh_entry])
+    assert len(dataset) == 1
+
+    entries = list(descent.utils.dataset.iter_dataset(dataset))
+    assert entries == expected_entries
+
+
+def test_create_dataset_from_generator(mock_meoh_entry):
+    expected_entries = [
+        {
+            "smiles": mock_meoh_entry["smiles"],
+            "coords": pytest.approx(mock_meoh_entry["coords"].flatten()),
+            "energy": pytest.approx(mock_meoh_entry["energy"]),
+            "forces": pytest.approx(mock_meoh_entry["forces"].flatten()),
+        },
+    ]
+
+    dataset = create_dataset_from_generator(lambda: iter([mock_meoh_entry]))
     assert len(dataset) == 1
 
     entries = list(descent.utils.dataset.iter_dataset(dataset))


### PR DESCRIPTION
## Description
Currently creating a dataset involves a `list[dict]` that is imported all at once into `descent.targets.energy.create_dataset()`. This requires that the entire dataset is held in memory.

HuggingFace dataset can be created with generators using `Dataset.from_generator()` but the Dataset is abstracted away in descent.

This PR adds a function `descent.targets.energy.create_dataset_from_generator()` to regain this capability from the `datasets` library.

*Marking as a draft until I successfully use this with my current work, just in case I run into an issue*

## Status
- [ ] Ready to go