### PR TITLE
Remove sphinx and pdf format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,10 +14,3 @@ build:
     build:
        html:
           - pixi run -e docs sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
-
-sphinx:
-  configuration: docs/conf.py
-  fail_on_warning: true
-
-formats:
-- pdf


### PR DESCRIPTION
Removed Sphinx configuration and PDF format from Read the Docs setup.

https://app.readthedocs.org/projects/descent-fitting/builds/33502293/

fix error in RTD:
```
python -m sphinx -T -b latex -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/pdf 0s Exit: 127
1	/bin/sh: 1: /home/docs/checkouts/readthedocs.org/user_builds/yammbs/envs/latest/bin/python: not found
```

## Description
Provide a brief description of the PR's purpose here.

## Status
- [ ] Ready to go