### PR TITLE
No `wheel`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=80", "setuptools-scm>=8", "wheel" ]
+requires = [ "setuptools>=80", "setuptools-scm>=8" ]
 
 [project]
 name = "descent"


### PR DESCRIPTION
## Description
`wheel` used to be necessary ~everywhere, now it's discouraged

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended, as the backend no longer requires the wheel package, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).

https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use

## Status
- [x] Ready to go