### PR TITLE
More robust exclusion and inclusion of PotentialKeys

### DIFF
--- a/descent/tests/test_train.py
+++ b/descent/tests/test_train.py
@@ -498,6 +498,25 @@ class TestTrainable:
         # the sole lone pair is excluded, so nothing remains trainable.
         assert trainable._unfrozen_idxs.numel() == 0
 
+    def test_init_vsites_include_key_without_virtual_site_type(self, water_sites_ff):
+        # As above, a user references the lone pair the way its key prints, but
+        # without the interchange-only virtual_site_type, but this time we include
+        # it rather than exclude it.
+        included = openff.interchange.models.PotentialKey(
+            id="[#1:2]-[#8X2H2+0:1]-[#1:3] EP once",
+            associated_handler="VirtualSites",
+        )
+
+        trainable = Trainable(
+            water_sites_ff,
+            parameters={},
+            attributes={},
+            vsites=ParameterConfig(cols=["distance"], include=[included]),
+        )
+
+        # The sole lone pair we included
+        assert trainable._unfrozen_idxs.numel() == 1
+
     @pytest.fixture()
     def cosmetic_bond_ff(self):
         """A force field whose first (C-C) bond parameter carries a cosmetic

--- a/descent/train.py
+++ b/descent/train.py
@@ -145,28 +145,30 @@ class Trainable:
     """
 
     @staticmethod
-    def _strip_irrelevant_values_from_potential_key(
-        potential_key: openff.interchange.models.PotentialKey,
-    ) -> openff.interchange.models.PotentialKey:
-        """
-        Strip out values defined on a `PotentialKey` that are not relevant for
-        determining whether a parameter should be excluded from training.
+    def _permissive_key_eq(
+        key1: openff.interchange.models.PotentialKey,
+        key2: openff.interchange.models.PotentialKey,
+    ) -> bool:
+        """Compare two potential keys for equality, ignoring irrelevant values.
 
-        This removes
-          * `PotentialKey.cosmetic_attributes`
-          * `PotentialKey.virtual_site_type`
+        The fields compared are
+        * `PotentialKey.id`
+        * `PotentialKey.mult`
+        * `PotentialKey.associated_handler`
+        * `PotentialKey.bond_order`
 
-        This does not remove
-          * `PotentialKey.id`
-          * `PotentialKey.associated_handler`
-          * `PotentialKey.mult`
-          * `PotentialKey.bond_order`
+        Fields ignored are
+        * `PotentialKey.cosmetic_attributes`
+        * `PotentialKey.virtual_site_type`
+
+        This is used to determine whether a parameter should be excluded from,
+        or included in, training.
         """
-        return openff.interchange.models.PotentialKey(
-            id=potential_key.id,
-            associated_handler=potential_key.associated_handler,
-            mult=potential_key.mult,
-            bond_order=potential_key.bond_order,
+        return (
+            key1.id == key2.id
+            and key1.mult == key2.mult
+            and key1.associated_handler == key2.associated_handler
+            and key1.bond_order == key2.bond_order
         )
 
     @staticmethod
@@ -181,31 +183,26 @@ class Trainable:
 
         assert all_keys is not None
 
-        excluded_keys = config.exclude or []
-        # TODO: Possibly strip irrelevant fields from included keys as well
-        unfrozen_keys = config.include or all_keys
+        assert len(all_keys) == len(set(all_keys)), "duplicate keys found"
 
-        key_to_row = {key: row_idx for row_idx, key in enumerate(all_keys)}
-        assert len(key_to_row) == len(all_keys), "duplicate keys found"
+        unfrozen_rows = set()
+        for i, key in enumerate(all_keys):
+            if config.include:
+                if not any(
+                    Trainable._permissive_key_eq(key, included_key)
+                    for included_key in config.include
+                ):
+                    continue
+            if config.exclude:
+                if any(
+                    Trainable._permissive_key_eq(key, excluded_key)
+                    for excluded_key in config.exclude
+                ):
+                    continue
 
-        # If a key in excluded_keys has defined attributes that we want to ignore, we
-        # want to ignore them, so strip them out. See for example
-        # `test_init_vsites_exclude_key_without_virtual_site_type`
-        stripped_excluded_keys = [
-            Trainable._strip_irrelevant_values_from_potential_key(key)
-            for key in excluded_keys
-        ]
+            unfrozen_rows.add(i)
 
-        # Do the same thing when checking whether or not the unfrozen keys are in the
-        # excluded keys, but avoid modifying unfrozen_keys in place to avoid surprising
-        # side effects. See `test_init_exclude_key_without_cosmetic_attributes` for an
-        # example of this in use.
-        return {
-            key_to_row[key]
-            for key in unfrozen_keys
-            if Trainable._strip_irrelevant_values_from_potential_key(key)
-            not in stripped_excluded_keys
-        }
+        return unfrozen_rows
 
     @staticmethod
     def _prepare_values(


### PR DESCRIPTION
## Description
The first commit here adds a test which illustrates the failure suggested by the Copilot review, and the second is my suggested solution. This makes sure that we never bypass the modified equality checking logic, or end up with lookup errors in the `key_to_row` dict.

My thinking was that `_permissive_key_eq` should give us an easy was to make the equality checking fancier in future too -- for example only comparing fields which aren't None in the exclude or include lists.

## Status
- [x] Ready to go